### PR TITLE
#16 remove icon and badge label for subject and classification records

### DIFF
--- a/public/views/shared/_idbadge.html.erb
+++ b/public/views/shared/_idbadge.html.erb
@@ -56,8 +56,8 @@ end
 
 <div class="badge-and-identifier">
   <div class="record-type-badge <%= (result.primary_type.start_with?('agent') ? 'agent' : result.primary_type) %>">
-    <%# BEGIN BC EDIT - remove subject icon %>
-    <% if result.primary_type != "subject" %> <i class="<%= icon_for_type(result.primary_type) %>"></i>&#160;<% end %><%= badge_label %> <% if result.container_summary_for_badge %> &mdash; <%= result.container_summary_for_badge %><% end %>
+    <%# BEGIN BC EDIT - dont display icon and badge label for subejct and classifcation records  %>
+    <% if (result.primary_type != "subject") && (result.primary_type != "classification") %> <i class="<%= icon_for_type(result.primary_type) %>"></i>&#160;<%= badge_label %> <% if result.container_summary_for_badge %> &mdash; <%= result.container_summary_for_badge %><% end %><% end %>
     <%# END BC EDIT %>
   </div>
   <% comp_id = display_component_id(result, props.fetch(:infinite_item, false)) %>


### PR DESCRIPTION
Modified /public/views/shared/idbadge.html.erb so that icon and badge label are not displayed in search results for "Subject" and "Classification" records

Note: BC ArchivesSpace does not currently feature any Classifications.